### PR TITLE
Invalid multibyte escape sequence fix

### DIFF
--- a/bin/textmate
+++ b/bin/textmate
@@ -227,7 +227,7 @@ class TextmateInstaller < Thor
   # Copied from http://macromates.com/svn/Bundles/trunk/Support/lib/escape.rb
   # escape text to make it useable in a shell script as one “word” (string)
   def e_sh(str)
-  	str.to_s.gsub(/(?=[^a-zA-Z0-9_.\/\-\x7F-\xFF\n])/, '\\').gsub(/\n/, "'\n'").sub(/^$/, "''")
+  	str.to_s.gsub(/(?=[^a-zA-Z0-9_.\/\-\x7F-\xFF\n])/n, '\\').gsub(/\n/, "'\n'").sub(/^$/, "''")
   end
 
   def url_escape(str)


### PR DESCRIPTION
This fix removes the encoding of the regex in order to solve :

`invalid multibyte escape: /(?=[^a-zA-Z0-9_.\/\-\x7F-\xFF\n])/`

When running `textmate install`
